### PR TITLE
Fixed React 16 compatibility

### DIFF
--- a/lib/ScrollLock.js
+++ b/lib/ScrollLock.js
@@ -6,6 +6,10 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -162,8 +166,8 @@ var ScrollLock = function (_Component) {
 }(_react.Component);
 
 ScrollLock.propTypes = {
-    enabled: _react.PropTypes.bool,
-    className: _react.PropTypes.string
+    enabled: _propTypes2.default.bool,
+    className: _propTypes2.default.string
 };
 ScrollLock.defaultProps = {
     enabled: true,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-react": "^6.10.0",
     "jest": "^19.0.2",
     "pre-commit": "^1.2.2",
+    "prop-types": "^15.6.0",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2"

--- a/src/ScrollLock.jsx
+++ b/src/ScrollLock.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 const upKeys = [
     33, // pageUp


### PR DESCRIPTION
As described in #16 the former version was not ready for React v16 and this PR fixes this. This was only the import of the PropTypes which has moved to the prop-types package.